### PR TITLE
chore: [SIW-2710] Refactor `NfcError`

### DIFF
--- a/android/src/main/java/com/pagopa/ioreactnativecie/IoReactNativeCieModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativecie/IoReactNativeCieModule.kt
@@ -200,7 +200,7 @@ class IoReactNativeCieModule(reactContext: ReactApplicationContext) :
             .emit(EventType.ERROR.value, WritableNativeMap().apply {
               putString("name", mapNfcError(error).name)
               error.msg?.let { putString("msg", it) }
-              error.numberOfAttempts?.let { putInt("attempts", it) }
+              error.numberOfAttempts?.let { putInt("attemptsLeft", it) }
             })
 
         }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - hermes-engine (0.78.2):
     - hermes-engine/Pre-built (= 0.78.2)
   - hermes-engine/Pre-built (0.78.2)
-  - IoReactNativeCie (1.0.0):
+  - IoReactNativeCie (1.0.1):
     - CieSDK (~> 0.1.11)
     - DoubleConversion
     - glog
@@ -2160,7 +2160,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: 2771b98fb813fdc6f92edd7c9c0035ecabf9fee7
-  IoReactNativeCie: bbccb9bb50d760a71f228d62962f089044116deb
+  IoReactNativeCie: 2cce5c212703e82de3436902430dbfb9fd07cc62
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: be794de7dc6ed8f9f7fbf525f86e7651b8b68746
   RCTRequired: a83787b092ec554c2eb6019ff3f5b8d125472b3b

--- a/ios/IoReactNativeCie.swift
+++ b/ios/IoReactNativeCie.swift
@@ -161,8 +161,8 @@ class IoReactNativeCie: RCTEventEmitter {
       }
     case .errorBuildingApdu, .responseError:
       payload = [ "name": ErrorType.APDU_ERROR.rawValue, "message": error.description ]
-    case .wrongPin(let attempts):
-      payload = [ "name":ErrorType.WRONG_PIN.rawValue, "message": error.description, "attempts": attempts ]
+    case .wrongPin(let attemptsLeft):
+      payload = [ "name":ErrorType.WRONG_PIN.rawValue, "message": error.description, "attemptsLeft": attemptsLeft ]
     case .cardBlocked:
       payload = [ "name": ErrorType.CARD_BLOCKED.rawValue, "message": error.description ]
     case .sslError:

--- a/src/manager/types.ts
+++ b/src/manager/types.ts
@@ -58,11 +58,11 @@ export const NfcError = z.union([
     name: NfcErrorName.exclude(['WRONG_PIN']),
     message: z.string().optional(),
   }),
-  // WRONG_PIN error contains the number of attempts left, that can be 1 or 2 (0 means CARD_BLOCKED)
+  // WRONG_PIN error also contains the number of attempts left
   z.object({
     name: NfcErrorName.extract(['WRONG_PIN']),
     message: z.string().optional(),
-    attemptsLeft: z.union([z.literal(1), z.literal(2)]),
+    attemptsLeft: z.number(),
   }),
 ]);
 

--- a/src/manager/types.ts
+++ b/src/manager/types.ts
@@ -52,17 +52,17 @@ export type NfcErrorName = z.infer<typeof NfcErrorName>;
 
 /**
  * Represent an NFC error emitted during the CIE reading process
- * It contains the name of the error, the message and the number of attempts
  */
 export const NfcError = z.union([
   z.object({
-    name: NfcErrorName,
+    name: NfcErrorName.exclude(['WRONG_PIN']),
     message: z.string().optional(),
   }),
+  // WRONG_PIN error contains the number of attempts left, that can be 1 or 2 (0 means CARD_BLOCKED)
   z.object({
-    name: z.literal(NfcErrorName.enum.WRONG_PIN),
+    name: NfcErrorName.extract(['WRONG_PIN']),
     message: z.string().optional(),
-    attempts: z.number(),
+    attemptsLeft: z.union([z.literal(1), z.literal(2)]),
   }),
 ]);
 


### PR DESCRIPTION
## Short description

This PR refactors the `NfcError` type to improve wrong PIN left attemps information handling

## List of changes proposed in this pull request

- Updated `NfcError` with correct `Zod` usage
- Renamed `attempts` to `attemptsLeft` to clarify what it refers to
- Aligned `Podfile.lock` on the example app

## How to test

Using the example app, try to read the CIE with a wrong PIN and check that the error message contains the `attemptsLeft` data
