### PR TITLE
chore: [SIW-2734] Android release workflow

### DIFF
--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -3,10 +3,13 @@ name: Build Android Example APK and AAB and Attach to Release
 on:
   pull_request:
     branches: [main]
+  # release:
+  #  types: [created]
 
 jobs:
   build-android-example:
     runs-on: ubuntu-latest
+    # if: contains(github.event.release.name, 'Example') || contains(github.event.release.name, 'example')
     permissions:
       contents: write
     env:
@@ -67,21 +70,19 @@ jobs:
           ls -la example/android/app/build/outputs/bundle/ || echo "Bundle directory not found"
 
       - name: Upload APK to Release
-        uses: actions/upload-release-asset@v1
+        continue-on-error: true
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ steps.find-artifacts.outputs.apk_path }}
-          asset_name: io-react-native-cie-example-${{ github.event.release.tag_name }}.apk
-          asset_content_type: application/vnd.android.package-archive
+          name: io-react-native-cie-example-${{ github.event.release.tag_name }}.apk
+          path: ${{ steps.find-artifacts.outputs.apk_path }}
 
       - name: Upload AAB to Release
-        uses: actions/upload-release-asset@v1
+        continue-on-error: true
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ steps.find-artifacts.outputs.aab_path }}
-          asset_name: io-react-native-cie-example-${{ github.event.release.tag_name }}.aab
-          asset_content_type: application/x-authorware-bin
+          name: io-react-native-cie-example-${{ github.event.release.tag_name }}.aab
+          path: ${{ steps.find-artifacts.outputs.aab_path }}

--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -1,0 +1,85 @@
+name: Build Android Example APK and AAB and Attach to Release
+
+on: workflow_dispatch
+
+jobs:
+  build-android-example:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      TURBO_CACHE_DIR: .turbo/android
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Cache turborepo for Android
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ${{ env.TURBO_CACHE_DIR }}
+          key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-turborepo-android-
+
+      - name: Install JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
+      - name: Finalize Android SDK
+        run: |
+          /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
+
+      - name: Cache Gradle
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: |
+            ~/.gradle/wrapper
+            ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('example/android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build Android APK and AAB
+        env:
+          JAVA_OPTS: "-XX:MaxHeapSize=6g"
+        run: |
+          cd example/android
+          ./gradlew assembleRelease bundleRelease
+
+      - name: Find APK and AAB paths
+        id: find-artifacts
+        run: |
+          APK_PATH=$(find example/android/app/build/outputs/apk/release -name "*.apk" | head -1)
+          AAB_PATH=$(find example/android/app/build/outputs/bundle -name "*.aab" | head -1)
+          echo "apk_path=$APK_PATH" >> $GITHUB_OUTPUT
+          echo "apk_name=$(basename $APK_PATH)" >> $GITHUB_OUTPUT
+          echo "aab_path=$AAB_PATH" >> $GITHUB_OUTPUT
+          echo "aab_name=$(basename $AAB_PATH)" >> $GITHUB_OUTPUT
+          echo "Debug: APK found at $APK_PATH"
+          echo "Debug: AAB found at $AAB_PATH"
+          ls -la example/android/app/build/outputs/bundle/ || echo "Bundle directory not found"
+
+      - name: Upload APK to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.find-artifacts.outputs.apk_path }}
+          asset_name: io-react-native-cie-example-${{ github.event.release.tag_name }}.apk
+          asset_content_type: application/vnd.android.package-archive
+
+      - name: Upload AAB to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.find-artifacts.outputs.aab_path }}
+          asset_name: io-react-native-cie-example-${{ github.event.release.tag_name }}.aab
+          asset_content_type: application/x-authorware-bin

--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -1,15 +1,13 @@
-name: Build Android Example APK and AAB and Attach to Release
+name: Build Android Example App
 
 on:
-  pull_request:
-    branches: [main]
-  # release:
-  #  types: [created]
+  release:
+    types: [created]
 
 jobs:
   build-android-example:
     runs-on: ubuntu-latest
-    # if: contains(github.event.release.name, 'Example') || contains(github.event.release.name, 'example')
+    if: contains(github.event.release.name, 'Example') || contains(github.event.release.name, 'example')
     permissions:
       contents: write
     env:

--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -1,6 +1,8 @@
 name: Build Android Example APK and AAB and Attach to Release
 
-on: workflow_dispatch
+on:
+  pull_request:
+    branches: [main]
 
 jobs:
   build-android-example:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: prod
+    if: "!contains(github.event.release.name, 'Example') && !contains(github.event.release.name, 'example')"
     steps:
       - name: Checkout
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846


### PR DESCRIPTION
## Short description

This PR adds a GitHub workflow to release the APK and AAB when an Example app release is created

## List of changes proposed in this pull request

- Added [build-android-release.yml](https://github.com/pagopa/io-react-native-cie/pull/4/files#diff-8e18cad86729b79a99701b1cd310a8f3ec1116cfdb308e6413b434cacd22fcdd)
- Updated [publish.yml](https://github.com/pagopa/io-react-native-cie/pull/4/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7) which now runs only if the release's name does not contain "Example"

## How to test

The action should be tested on the main branch
