### PR TITLE
fix: [SIW-2756] Fix return types for CIeUtils functions

### DIFF
--- a/android/src/main/java/com/pagopa/ioreactnativecie/IoReactNativeCieModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativecie/IoReactNativeCieModule.kt
@@ -93,15 +93,13 @@ class IoReactNativeCieModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun setAlertMessage(key: String, value: String, promise: Promise) {
+  fun setAlertMessage(key: String, value: String) {
     // Android does not support alert messages for NFC reading
-    promise.resolve(null)
   }
 
   @ReactMethod
-  fun setCurrentAlertMessage(value: String, promise: Promise) {
+  fun setCurrentAlertMessage(value: String) {
     // Android does not support alert messages for NFC reading
-    promise.resolve(null)
   }
 
   @ReactMethod

--- a/src/manager/index.ts
+++ b/src/manager/index.ts
@@ -66,7 +66,7 @@ const removeAllListeners = () => {
  * ```
  */
 const setCustomIdpUrl = (url: string | undefined) => {
-  return IoReactNativeCie.setCustomIdpUrl(url ?? getDefaultIdpUrl());
+  IoReactNativeCie.setCustomIdpUrl(url ?? getDefaultIdpUrl());
 };
 
 /**
@@ -82,7 +82,7 @@ const setCustomIdpUrl = (url: string | undefined) => {
  * ```
  */
 export const setAlertMessage = (key: AlertMessageKey, value: string) => {
-  return IoReactNativeCie.setAlertMessage(key, value);
+  IoReactNativeCie.setAlertMessage(key, value);
 };
 
 /**
@@ -97,7 +97,7 @@ export const setAlertMessage = (key: AlertMessageKey, value: string) => {
  * ```
  */
 export const setCurrentAlertMessage = (value: string) => {
-  return IoReactNativeCie.setCurrentAlertMessage(value);
+  IoReactNativeCie.setCurrentAlertMessage(value);
 };
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,7 +8,7 @@ import { IoReactNativeCie } from '../native';
  * @returns A promise that resolves to true if the device supports NFC, false otherwise.
  * @throws {CieError} If cannot check if NFC is available.
  */
-export const hasNfcFeature = async () => {
+export const hasNfcFeature = async (): Promise<boolean> => {
   return IoReactNativeCie.hasNfcFeature();
 };
 
@@ -20,7 +20,7 @@ export const hasNfcFeature = async () => {
  * @returns A promise that resolves to true if NFC is enabled, false otherwise.
  * @throws {CieError} If cannot check if NFC is enabled.
  */
-export const isNfcEnabled = async () => {
+export const isNfcEnabled = async (): Promise<boolean> => {
   return IoReactNativeCie.isNfcEnabled();
 };
 
@@ -28,7 +28,7 @@ export const isNfcEnabled = async () => {
  * Verifies if the device supports CIE (Electronic Identity Card) authentication.
  * @returns A promise that resolves to true if CIE authentication is supported, false otherwise.
  */
-export const isCieAuthenticationSupported = async () => {
+export const isCieAuthenticationSupported = async (): Promise<boolean> => {
   return IoReactNativeCie.isCieAuthenticationSupported();
 };
 
@@ -37,6 +37,6 @@ export const isCieAuthenticationSupported = async () => {
  * @returns A promise that resolves when the settings page is opened.
  * @throws {CieError} If cannot open the settings page.
  */
-export const openNfcSettings = async () => {
+export const openNfcSettings = async (): Promise<boolean> => {
   return IoReactNativeCie.openNfcSettings();
 };


### PR DESCRIPTION
## Short description

This PR fixes the return types of the `CieUtils` module

## List of changes proposed in this pull request

- Removed unnecessary `promise.resolve` in `setAlertMessage` and `setCurrentAlertMessage` Android methods
- Removed unnecessary return statement in `setCustomIdpUrl`, `setAlertMessage` and `setCurrentAlertMessage` methods
- Added correct return types in `CieUtils` module

## How to test

NFC status, attributes read process and authentication flow should work as expected
