### PR TITLE
chore: [IOPID-2404] bump `it.pagopa.io.app.cie` from `0.1.4` to `0.1.5`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,6 +78,6 @@ dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   // CIE SDK
-  implementation "it.pagopa.io.app.cie:cie:0.1.4"
+  implementation "it.pagopa.io.app.cie:cie:0.1.5"
 }
 


### PR DESCRIPTION
## Short description

This PR bumps `it.pagopa.io.app.cie` from `0.1.4` to `0.1.5`

## How to test

Run the android example app and try a successful CIE+PIN read.
